### PR TITLE
Add Clusy to Adjacent (ML notebook platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Related but not untrusted-code sandboxes for coding agents:
 - [CodeSandbox SDK](https://codesandbox.io) - microVM CDE (now part of Together AI); primarily a dev environment.
 - [GitHub Codespaces](https://github.com/features/codespaces) - Cloud dev environments; see also [Replit](https://replit.com).
 - [Steel.dev](https://steel.dev) - Sandboxed browser sessions (not general code exec).
+- [Clusy](https://www.clusy.io) - Agent-native notebook for ML/data science; managed-only, runs agent-written cells on cloud CPU/GPU "managed cloud sandboxes". Isolation mechanism, tenant boundary and egress controls undocumented; workspace separation stated as logical only.
 - [ComputeSDK](https://computesdk.com) - Provider-agnostic router/SDK across sandbox backends (no own isolation); see also [VibeKit](https://docs.vibekit.sh).
 - [agentbox (madarco)](https://github.com/madarco/agentbox) - Self-hosted CLI running coding agents in parallel (Docker+FUSE / cloud VM); dev-workflow tooling on off-the-shelf isolation. MIT.
 - [Giant Swarm Agent Platform](https://www.giantswarm.io/agent-platform) - Kubernetes-based agent governance/orchestration control plane (MCP); ships no dedicated untrusted-code sandbox.


### PR DESCRIPTION
Adds [Clusy](https://www.clusy.io) to `Adjacent`.

**Why Adjacent and not the matrix:** application-layer agent notebook for ML/data science, not a sandbox API for running untrusted agent code. Same treatment as Steel.dev.

**Verification (clusy.io + /security, checked 2026-08-03):**

| Claim | Status |
|---|---|
| Isolation mechanism (VM/µVM/container/kernel) | Not documented. Site says only "Every plan runs on managed cloud sandboxes"; the security page names no compute boundary. |
| Tenant separation | "Customer datasets, training artifacts, and logs are logically separated by workspace" — logical only, enforcement undocumented. |
| Egress control | Not documented; sandboxes reach the public internet (agent pulls datasets from Hugging Face / OSF). |
| Secrets | "Stored in managed secret stores with access logging and rotation" — platform-side storage, not brokered out of the sandbox. |
| Self-host | No option documented; managed only. |

The suggestion that prompted this described "replicated kernels" and per-branch "isolated cloud kernel state". Neither phrase appears in Clusy's public docs, so it is not repeated in the entry.