### PR TITLE
Add ItemList JSON-LD generated from the README matrix

### DIFF
--- a/.github/workflows/data-sync.yml
+++ b/.github/workflows/data-sync.yml
@@ -1,0 +1,17 @@
+# The ItemList JSON-LD is built from _data/sandboxes.json, which is generated
+# from the README matrix. A PR that edits the matrix without regenerating would
+# ship schema that disagrees with the visible table — this catches that.
+name: data-sync
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 script/sandboxes-data.py --demo
+      - run: python3 script/sandboxes-data.py --check

--- a/_data/sandboxes.json
+++ b/_data/sandboxes.json
@@ -1,0 +1,685 @@
+[
+  {
+    "@type": "ListItem",
+    "position": 1,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Cleanroom",
+      "url": "https://github.com/buildkite/cleanroom",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker µVM isolation",
+        "deny-default egress control",
+        "brokered secrets",
+        "Self-host",
+        "ephemeral workspace"
+      ],
+      "license": "https://opensource.org/licenses/MIT"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 2,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "smolvm (smol-machines)",
+      "url": "https://github.com/smol-machines/smolvm",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "libkrun µVM isolation",
+        "deny-default egress control",
+        "brokered secrets",
+        "Self-host",
+        "ephemeral and persistent workspace"
+      ],
+      "license": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 3,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Leap0",
+      "url": "https://leap0.dev",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker µVM isolation",
+        "deny-default (allowlist) egress control",
+        "brokered secrets",
+        "Both",
+        "ephemeral and persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 4,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "InstaVM",
+      "url": "https://instavm.io",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker µVM isolation",
+        "deny-default (allowlist) egress control",
+        "brokered secrets",
+        "Both",
+        "ephemeral and persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 5,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Mitos",
+      "url": "https://mitos.run",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker µVM (Kubernetes) isolation",
+        "deny-default egress control",
+        "brokered secrets",
+        "Both",
+        "persistent workspace"
+      ],
+      "license": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 6,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Sprites (Fly.io)",
+      "url": "https://fly.io/sprites",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker µVM isolation",
+        "allowlist egress control",
+        "env-in secrets",
+        "Managed",
+        "persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 7,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "microsandbox",
+      "url": "https://github.com/superradcompany/microsandbox",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "libkrun µVM isolation",
+        "configurable (deny opt.) egress control",
+        "brokered secrets",
+        "Self-host (+cloud beta)",
+        "persistent workspace"
+      ],
+      "license": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 8,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Superserve",
+      "url": "https://superserve.ai",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker µVM isolation",
+        "configurable (allowlist) egress control",
+        "brokered secrets",
+        "Both",
+        "ephemeral and persistent workspace"
+      ],
+      "license": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 9,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Islo",
+      "url": "https://islo.dev",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Cloud Hypervisor µVM isolation",
+        "configurable (allow/deny) egress control",
+        "brokered secrets",
+        "Both (BYOC)",
+        "ephemeral and persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 10,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Declaw",
+      "url": "https://declaw.ai",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker µVM isolation",
+        "configurable (allow/deny, L7) egress control",
+        "brokered secrets",
+        "Both (BYOC)",
+        "ephemeral and persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 11,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "OmniRun",
+      "url": "https://omnirun.io",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker µVM isolation",
+        "configurable (allow/deny) egress control",
+        "env-in secrets",
+        "Both",
+        "ephemeral workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 12,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Vercel Sandbox",
+      "url": "https://github.com/vercel/sandbox",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker µVM isolation",
+        "configurable (deny-all) egress control",
+        "brokered secrets",
+        "Managed",
+        "ephemeral workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 13,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "BoxLite",
+      "url": "https://github.com/boxlite-ai/boxlite",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "KVM/HVF µVM isolation",
+        "configurable (allowlist) egress control",
+        "brokered secrets",
+        "Self-host",
+        "persistent workspace"
+      ],
+      "license": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 14,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "OpenComputer",
+      "url": "https://opencomputer.dev",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "KVM full VM isolation",
+        "configurable (allowlist, L7) egress control",
+        "brokered secrets",
+        "Both",
+        "persistent workspace"
+      ],
+      "license": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 15,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Blaxel",
+      "url": "https://blaxel.ai",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "µVM isolation",
+        "configurable (preview) egress control",
+        "brokered secrets",
+        "Managed",
+        "persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 16,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Qbox",
+      "url": "https://qbox.sh",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker µVM isolation",
+        "configurable egress control",
+        "unverified secrets",
+        "Self-host",
+        "ephemeral workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 17,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Katakate (k7)",
+      "url": "https://github.com/Katakate/k7",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Kata+FC µVM (K3s) isolation",
+        "configurable (allowlist) egress control",
+        "env-in secrets",
+        "Self-host",
+        "ephemeral workspace"
+      ],
+      "license": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 18,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "AgentENV",
+      "url": "https://github.com/kvcache-ai/AgentENV",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker µVM isolation",
+        "full-by-default (cfg) egress control",
+        "env-in secrets",
+        "Self-host",
+        "ephemeral and persistent workspace"
+      ],
+      "license": "https://opensource.org/licenses/MIT"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 19,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Freestyle",
+      "url": "https://freestyle.sh",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Full VM/KVM isolation",
+        "configurable (on/off) egress control",
+        "unverified secrets",
+        "Managed",
+        "ephemeral and persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 20,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Runloop",
+      "url": "https://runloop.ai",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "VM + container isolation",
+        "full-by-default (cfg) egress control",
+        "brokered secrets",
+        "Managed",
+        "persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 21,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "E2B",
+      "url": "https://e2b.dev",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker µVM isolation",
+        "full-by-default (cfg) egress control",
+        "env-in secrets",
+        "Both",
+        "ephemeral workspace"
+      ],
+      "license": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 22,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Northflank",
+      "url": "https://northflank.com",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Kata+FC µVM isolation",
+        "full-by-default egress control",
+        "env-in secrets",
+        "Both (BYOC)",
+        "persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 23,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Arrakis",
+      "url": "https://github.com/abshkbh/arrakis",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Cloud Hypervisor µVM isolation",
+        "full-by-default egress control",
+        "env-in secrets",
+        "Self-host",
+        "persistent workspace"
+      ],
+      "license": "https://www.gnu.org/licenses/agpl-3.0.html"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 24,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "SmolVM (Celesto AI)",
+      "url": "https://github.com/CelestoAI/SmolVM",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker+QEMU µVM isolation",
+        "full-by-default (allowlist) egress control",
+        "env-in secrets",
+        "Self-host",
+        "ephemeral and persistent workspace"
+      ],
+      "license": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 25,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Morph",
+      "url": "https://morph.so",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "µVM (VMM n/s) isolation",
+        "full-by-default egress control",
+        "env-in secrets",
+        "Both",
+        "ephemeral and persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 26,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Tensorlake",
+      "url": "https://tensorlake.ai",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker+CH µVM isolation",
+        "full-by-default (allow/deny) egress control",
+        "env-in secrets",
+        "Both (BYOC)",
+        "ephemeral and persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 27,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Box (ascii.dev)",
+      "url": "https://box.ascii.dev",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Linux VM isolation",
+        "full-by-default egress control",
+        "env-in secrets",
+        "Managed",
+        "persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 28,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Novita",
+      "url": "https://novita.ai/sandbox",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Firecracker µVM isolation",
+        "full-by-default egress control",
+        "unverified secrets",
+        "Managed",
+        "ephemeral and persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 29,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Baponi",
+      "url": "https://baponi.ai",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Container (seccomp+cgroups, zero-cap) isolation",
+        "deny-default egress control",
+        "brokered secrets",
+        "Both",
+        "ephemeral and persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 30,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "OpenSandbox",
+      "url": "https://github.com/alibaba/OpenSandbox",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Container (opt. gVisor/Kata/FC) isolation",
+        "configurable (deny avail.) egress control",
+        "brokered secrets",
+        "Self-host",
+        "ephemeral workspace"
+      ],
+      "license": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 31,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Cloudflare Sandboxes",
+      "url": "https://developers.cloudflare.com/sandbox/",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "VM-backed container isolation",
+        "configurable (deny avail.) egress control",
+        "brokered secrets",
+        "Managed",
+        "ephemeral and persistent workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 32,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Daytona",
+      "url": "https://daytona.io",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Container (ded. kernel) isolation",
+        "configurable (tier-gated) egress control",
+        "brokered secrets",
+        "Both",
+        "persistent workspace"
+      ],
+      "license": "https://www.gnu.org/licenses/agpl-3.0.html"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 33,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "AIO Sandbox",
+      "url": "https://github.com/agent-infra/sandbox",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Container (Docker) isolation",
+        "configurable (proxy) egress control",
+        "env-in secrets",
+        "Self-host",
+        "ephemeral workspace"
+      ],
+      "license": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 34,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Modal",
+      "url": "https://modal.com",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "gVisor isolation",
+        "full-by-default (cfg) egress control",
+        "env-in secrets",
+        "Managed",
+        "ephemeral workspace"
+      ]
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 35,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Beam",
+      "url": "https://beam.cloud",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "gVisor + runc isolation",
+        "full-by-default (cfg) egress control",
+        "env-in secrets",
+        "Both",
+        "persistent workspace"
+      ],
+      "license": "https://www.gnu.org/licenses/agpl-3.0.html"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 36,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "Kubernetes Agent Sandbox",
+      "url": "https://github.com/kubernetes-sigs/agent-sandbox",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "gVisor/Kata (pluggable) isolation",
+        "none (delegated) egress control",
+        "env-in secrets",
+        "Self-host (Kubernetes)",
+        "persistent workspace"
+      ],
+      "license": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  {
+    "@type": "ListItem",
+    "position": 37,
+    "item": {
+      "@type": "SoftwareApplication",
+      "name": "OpenHands",
+      "url": "https://github.com/OpenHands/OpenHands",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux",
+      "featureList": [
+        "Container (Docker) isolation",
+        "none egress control",
+        "env-in secrets",
+        "Both"
+      ],
+      "license": "https://opensource.org/licenses/MIT"
+    }
+  }
+]

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -20,7 +20,7 @@
       "@type": "Dataset",
       "@id": "{{ '/' | absolute_url }}#dataset",
       "name": "AI Coding Agent Sandboxes — Security Posture Comparison",
-      "description": "Comparison of 37 sandbox platforms for running AI coding agent code, scored on isolation tier (microVM, gVisor, container, process), egress control (deny-default, allowlist, configurable, full-by-default), secrets handling (brokered vs env-in), hosting model, workspace state and license.",
+      "description": "Comparison of {{ site.data.sandboxes | size }} sandbox platforms for running AI coding agent code, scored on isolation tier (microVM, gVisor, container, process), egress control (deny-default, allowlist, configurable, full-by-default), secrets handling (brokered vs env-in), hosting model, workspace state and license.",
       "url": "{{ '/' | absolute_url }}#comparison-matrix",
       "license": "https://creativecommons.org/publicdomain/zero/1.0/",
       "keywords": ["AI coding agents","sandbox","microVM","Firecracker","gVisor","egress control","secrets brokering","isolation"],
@@ -43,7 +43,17 @@
         {"@type": "PropertyValue", "name": "Workspace state"},
         {"@type": "PropertyValue", "name": "License"}
       ],
-      "creator": {"@id": "https://github.com/fhiltscher#person"}
+      "creator": {"@id": "https://github.com/fhiltscher#person"},
+      "mainEntity": {"@id": "{{ '/' | absolute_url }}#itemlist"}
+    },
+    {
+      "@type": "ItemList",
+      "@id": "{{ '/' | absolute_url }}#itemlist",
+      "name": "AI coding agent sandboxes ranked by security posture",
+      "description": "Sandbox platforms ordered by isolation tier, then egress control strength — strongest posture first.",
+      "itemListOrder": "https://schema.org/ItemListOrderDescending",
+      "numberOfItems": {{ site.data.sandboxes | size }},
+      "itemListElement": {{ site.data.sandboxes | jsonify }}
     },
     {
       "@type": "TechArticle",
@@ -56,6 +66,8 @@
       "inLanguage": "en-US",
       "license": "https://creativecommons.org/publicdomain/zero/1.0/",
       "author": {"@id": "https://github.com/fhiltscher#person"},
+      "publisher": {"@id": "https://github.com/fhiltscher#person"},
+      "about": {"@id": "{{ '/' | absolute_url }}#itemlist"},
       "mainEntity": {"@id": "{{ '/' | absolute_url }}#dataset"},
       "mainEntityOfPage": "{{ '/' | absolute_url }}"
     },
@@ -63,6 +75,7 @@
       "@type": "Person",
       "@id": "https://github.com/fhiltscher#person",
       "name": "Franz Hiltscher",
+      "description": "Maintainer of the awesome-ai-coding-sandboxes security posture comparison.",
       "url": "https://github.com/fhiltscher",
       "sameAs": [
         "https://github.com/fhiltscher",

--- a/script/sandboxes-data.py
+++ b/script/sandboxes-data.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Generate _data/sandboxes.json from the comparison matrix in README.md.
+
+The README table is the single source of truth. This turns it into the data
+Jekyll needs for the ItemList JSON-LD (_includes/head-custom.html).
+
+    script/sandboxes-data.py            regenerate _data/sandboxes.json
+    script/sandboxes-data.py --check    fail if it is out of sync (CI)
+
+Run it after touching the matrix, or CI will tell you off.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+README = ROOT / "README.md"
+OUT = ROOT / "_data" / "sandboxes.json"
+
+# The matrix, not the "Isolation building blocks" table further down.
+SECTION = ("## Comparison matrix", "### What the data shows")
+
+LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+FOOTNOTE = re.compile(r"\[\^[^\]]+\]")
+
+# Only OSI/FSF licenses get a URL; "Prop." and "unverified" carry no identifier.
+LICENSE_URLS = {
+    "MIT": "https://opensource.org/licenses/MIT",
+    "Apache": "https://www.apache.org/licenses/LICENSE-2.0",
+    "AGPL": "https://www.gnu.org/licenses/agpl-3.0.html",
+}
+
+STATE_LABELS = {
+    "eph": "ephemeral workspace",
+    "pers": "persistent workspace",
+    "both": "ephemeral and persistent workspace",
+}
+
+
+def clean(cell):
+    """Strip markdown emphasis and footnote refs from a table cell."""
+    return FOOTNOTE.sub("", cell).replace("**", "").replace("_", "").strip()
+
+
+def matrix_rows(text):
+    """Yield the data rows of the comparison matrix as lists of cells."""
+    start, end = text.index(SECTION[0]), text.index(SECTION[1])
+    for line in text[start:end].splitlines():
+        line = line.strip()
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if cells[0] == "Project" or set(cells[0]) <= {"-", " "}:
+            continue  # header / separator
+        yield cells
+
+
+def to_item(position, cells):
+    project, isolation, egress, secrets, hosting, state, license_ = cells
+
+    link = LINK.search(project)
+    if not link:
+        raise SystemExit(f"row {position}: no project link in {project!r}")
+
+    features = [
+        f"{clean(isolation)} isolation",
+        f"{clean(egress)} egress control",
+        f"{clean(secrets)} secrets",
+        clean(hosting),
+    ]
+    if label := STATE_LABELS.get(clean(state)):
+        features.append(label)
+
+    item = {
+        "@type": "SoftwareApplication",
+        "name": clean(link.group(1)),
+        "url": link.group(2),
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Linux",
+        "featureList": features,
+    }
+    if url := LICENSE_URLS.get(clean(license_)):
+        item["license"] = url
+
+    return {"@type": "ListItem", "position": position, "item": item}
+
+
+def build():
+    rows = list(matrix_rows(README.read_text(encoding="utf-8")))
+    return [to_item(i, cells) for i, cells in enumerate(rows, start=1)]
+
+
+def main():
+    items = build()
+    payload = json.dumps(items, indent=2, ensure_ascii=False) + "\n"
+
+    if "--check" in sys.argv:
+        current = OUT.read_text(encoding="utf-8") if OUT.exists() else ""
+        if current != payload:
+            sys.exit(
+                "_data/sandboxes.json is out of sync with the README matrix.\n"
+                "Run: script/sandboxes-data.py"
+            )
+        print(f"in sync ({len(items)} entries)")
+        return
+
+    OUT.parent.mkdir(exist_ok=True)
+    OUT.write_text(payload, encoding="utf-8")
+    print(f"wrote {OUT.relative_to(ROOT)} ({len(items)} entries)")
+
+
+def demo():
+    """Self-check against the real README."""
+    items = build()
+    assert len(items) >= 30, f"expected the full matrix, got {len(items)}"
+    assert [i["position"] for i in items] == list(range(1, len(items) + 1))
+
+    first = items[0]["item"]
+    assert first["name"] == "Cleanroom", first["name"]
+    assert first["url"].startswith("http")
+    assert "deny-default egress control" in first["featureList"]
+    assert first["license"] == LICENSE_URLS["MIT"]
+
+    # Footnote refs must not leak into names or feature strings.
+    blob = json.dumps(items)
+    assert "[^" not in blob and "**" not in blob
+
+    names = [i["item"]["name"] for i in items]
+    assert "AgentENV" in names, "footnote-suffixed name mangled"
+    assert len(set(names)) == len(names), "duplicate project names"
+    print(f"ok — {len(items)} entries parsed")
+
+
+if __name__ == "__main__":
+    demo() if "--demo" in sys.argv else main()


### PR DESCRIPTION
The JSON-LD graph described the comparison matrix as a `Dataset`, but no
individual sandbox was machine-readable. That per-entry structure is what AI
search surfaces cite for "best sandbox for X" queries.

Replaces #5, which sat on `feat/seo-config` and conflicted — PRs #3/#4 were
squash-merged, so that branch replayed commits whose content is already in
`main`. This one is a clean cherry-pick onto `main`.

## What changed

- **`script/sandboxes-data.py`** parses the comparison matrix out of
  `README.md` into `_data/sandboxes.json` (37 entries; strips footnote refs
  and bold markers, maps OSI/FSF licenses to their URLs).
- **`_includes/head-custom.html`** renders that as an `ItemList` node wired to
  `Dataset.mainEntity` and `TechArticle.about`. Also adds the missing
  `publisher` on `TechArticle` and a `description` on the `Person` node, and
  replaces the hardcoded `37` in the dataset description with
  `{{ site.data.sandboxes | size }}`.
- **`.github/workflows/data-sync.yml`** fails the build when the matrix is
  edited without regenerating the data — accuracy is the whole point of the
  list, and silently stale schema would undercut that.

README stays the single source of truth. After touching the matrix, run:

    script/sandboxes-data.py

## Verification

- `script/sandboxes-data.py --demo` self-check passes (37 entries, positions
  contiguous, no footnote leakage, no duplicate names).
- Liquid substitution simulated and the resulting graph parsed as JSON — valid,
  all `@id` cross-references resolve.
- **Not verified:** no local Jekyll available, so the real site build is
  untested. Worth a Rich Results Test against the live URL after merge.