### PR TITLE
Regenerate ItemList data via an opt-in pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Keeps _data/sandboxes.json in step with the README matrix.
+#
+# Git hooks are not cloned, so this only runs for whoever enabled it:
+#
+#     git config core.hooksPath .githooks
+#
+# Contributors without it are still covered by the data-sync CI check — this
+# just turns that red check into something you never see in the first place.
+
+changed=$(git diff --cached --name-only)
+case "$changed" in
+	*README.md*|*script/sandboxes-data.py*) ;;
+	*) exit 0 ;;
+esac
+
+python3 script/sandboxes-data.py || exit 1
+git add _data/sandboxes.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,22 @@ This list lives or dies on accuracy. So:
 - **Persistence** — `ephemeral`, `persistent`, `both`, or `partial`.
 - **License** — SPDX id (e.g. `Apache-2.0`, `MIT`, `AGPL-3.0`) or `Proprietary`. Note if only the SDK/client is open (`Proprietary (SDK MIT)`).
 
+### Generated data
+
+The matrix also feeds the page's `ItemList` structured data via
+`_data/sandboxes.json`. It is generated — don't edit it by hand:
+
+```sh
+script/sandboxes-data.py
+```
+
+CI fails if it drifts from the README. To have it regenerate itself on every
+commit that touches the matrix, enable the repo's hooks once:
+
+```sh
+git config core.hooksPath .githooks
+```
+
 ## Reporting stale or wrong data
 
 Found an entry that's out of date or incorrect? **Open an issue or a PR.** Accuracy beats politeness — if a value has changed or was wrong, we want to fix it.


### PR DESCRIPTION
The `data-sync` check catches drift between the README matrix and
`_data/sandboxes.json`, but only after the fact: you push, the check goes red,
you run the script, you push again.

`.githooks/pre-commit` regenerates and stages the data whenever a commit
touches the matrix or the generator, so that round trip disappears. Hooks are
not cloned, so it is opt-in per checkout:

    git config core.hooksPath .githooks

## This does not replace the CI check

Fork PRs never run local hooks, and most contributions to a list like this come
from forks. `data-sync.yml` stays as the safety net; the hook just means the
maintainer rarely triggers it.

## Verification

Tested against a real matrix edit (Qbox license `unverified` → `MIT`): the hook
fired on commit, regenerated the data, and staged it into the same commit —
including the resulting `"license": "https://opensource.org/licenses/MIT"` in
the ItemList entry. Rolled back afterwards; `main` content is untouched.

The hook exits early when a commit touches neither `README.md` nor
`script/sandboxes-data.py`, so ordinary commits are unaffected.