### PR TITLE
Add issue forms and a PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-project.yml
+++ b/.github/ISSUE_TEMPLATE/add-project.yml
@@ -1,0 +1,50 @@
+name: Suggest a project
+description: Propose a sandbox or isolation solution for the list
+labels: [new entry]
+body:
+  - type: input
+    id: project
+    attributes:
+      label: Project
+      description: Name and official URL (repo or product page)
+      placeholder: Firecracker — https://github.com/firecracker-microvm/firecracker
+    validations:
+      required: true
+  - type: textarea
+    id: mechanism
+    attributes:
+      label: What enforces the isolation boundary?
+      description: One factual sentence. microVM, gVisor/user-space kernel, container, or process/namespace — and what it runs.
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: Source
+      description: Link to the official docs or repo page that backs the sentence above. Not a blog post, not a vendor comparison.
+    validations:
+      required: true
+  - type: dropdown
+    id: section
+    attributes:
+      label: Where does it belong?
+      options:
+        - VMs & microVMs
+        - Containers & gVisor
+        - Process & namespace sandboxes
+        - Filesystem & WebAssembly sandboxes
+        - Isolation building blocks
+        - Adjacent
+        - Not sure — happy to discuss
+    validations:
+      required: true
+  - type: checkboxes
+    id: criteria
+    attributes:
+      label: Inclusion criteria
+      description: See [CONTRIBUTING.md](https://github.com/fhiltscher/awesome-ai-coding-sandboxes/blob/main/CONTRIBUTING.md). License is not a criterion.
+      options:
+        - label: It executes agent-generated or agent-driven code — not just an agent framework
+          required: true
+        - label: It is publicly usable and documented, and not archived or dormant for 12 months
+          required: true

--- a/.github/ISSUE_TEMPLATE/wrong-data.yml
+++ b/.github/ISSUE_TEMPLATE/wrong-data.yml
@@ -1,0 +1,25 @@
+name: Report wrong or stale data
+description: A matrix cell, description or link that is out of date or incorrect
+labels: [data]
+body:
+  - type: input
+    id: entry
+    attributes:
+      label: Entry
+      description: Which project, and which column or line
+      placeholder: E2B — Egress control
+    validations:
+      required: true
+  - type: textarea
+    id: correction
+    attributes:
+      label: What it says vs. what it should say
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: Source
+      description: Official docs or repo page showing the correct value. Use `?` in the correction if the docs do not state it.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!-- One project per PR. See CONTRIBUTING.md. -->
+
+**Project:** <!-- name + official URL -->
+
+**Section:** <!-- VMs & microVMs / Containers & gVisor / Process & namespace / Filesystem & WebAssembly / Isolation building blocks / Adjacent -->
+
+**What it is:** <!-- one factual sentence: what enforces the isolation boundary -->
+
+## Sources
+
+<!-- Official docs or repo only — not a blog post, not a vendor comparison, not
+     this list. Quote the supporting phrase so a reviewer can verify without
+     re-researching. One line per claim you are making or changing. -->
+
+- Isolation:
+- Egress control:
+- Secrets:
+
+## Checklist
+
+- [ ] One project per PR
+- [ ] Entry is `- [Name](official-url) - One factual sentence.`, stating the mechanism, not the pitch
+- [ ] Every matrix cell I added or changed has a source above; unknown values are `?`, not guesses
+- [ ] If I touched the matrix: re-ran `script/sandboxes-data.py`
+- [ ] `npx awesome-lint` passes


### PR DESCRIPTION
Closes the `.github/` item of WE6.

**What**

- `.github/ISSUE_TEMPLATE/add-project.yml` — suggest a project. Required: official URL, one sentence on what enforces the boundary, a source link, target section. Two inclusion checkboxes (executes agent-driven code; publicly usable and not archived/dormant).
- `.github/ISSUE_TEMPLATE/wrong-data.yml` — report a wrong or stale value. Required: entry, is/should, source.
- `.github/PULL_REQUEST_TEMPLATE.md` — project, section, one-sentence mechanism, a source line per claim, and the checklist (one project per PR, item format, `?` instead of guesses, re-run `script/sandboxes-data.py`, `npx awesome-lint`).

**Why**

CONTRIBUTING already sets the bar; until now it was only reachable by reading the file before opening the issue. The forms ask for the source up front, which is the one thing a review of this list actually needs.

**Checks**

- `npx awesome-lint` — green (unchanged, no README edit in this PR).
- Both issue forms parse as YAML and use only supported field types.
- Labels `new entry` and `data` created on the repo so the forms can apply them.