### PR TITLE
Add distro-rig-vps

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Strongest isolation (own kernel per sandbox), built on Firecracker, libkrun, and
 - [Chamber](https://github.com/cirruslabs/chamber)
 - [Matchlock](https://github.com/jingkaihe/matchlock)
 - [Gondolin](https://github.com/earendil-works/gondolin)
-- [distro-rig-vps](https://github.com/shafir-info/distro-rig-vps)
+- [distro-rig-vps](https://github.com/shafir-info/distro-rig-vps) - Self-hosted KVM/libvirt sandbox giving coding agents guest root in disposable real-boot Linux VMs behind a constrained unprivileged host control API.
 
 ## Containers & gVisor
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Strongest isolation (own kernel per sandbox), built on Firecracker, libkrun, and
 - [Chamber](https://github.com/cirruslabs/chamber)
 - [Matchlock](https://github.com/jingkaihe/matchlock)
 - [Gondolin](https://github.com/earendil-works/gondolin)
+- [distro-rig-vps](https://github.com/shafir-info/distro-rig-vps)
 
 ## Containers & gVisor
 


### PR DESCRIPTION
**Project:** [distro-rig-vps](https://github.com/shafir-info/distro-rig-vps)

**Section:** VMs & microVMs

**What it is:** Self-hosted KVM/libvirt sandbox giving coding agents guest root in disposable real-boot Linux VMs behind a constrained unprivileged host control API.

## Sources

* Isolation: README — “root inside a disposable, real-boot Linux VM”; self-hosted on KVM/libvirt.
* Egress control: README — guest has no general route to the internet; default exceptions are the package cache and configured mock ports.
* Secrets: not claimed / not added to matrix.

## Checklist

* [x] One project per PR
* [x] Entry is `- [Name](official-url) - One factual sentence.`, stating the mechanism, not the pitch
* [x] Every matrix cell I added or changed has a source above; unknown values are `?`, not guesses
* [x] If I touched the matrix: not applicable
* [ ] `npx awesome-lint` passes