### PR TITLE
Add SandBase Harness sandbox runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Shared-kernel isolation; faster, weaker boundary — built on gVisor and Kata Co
 - [clampdown](https://github.com/89luca89/clampdown) - Hardened container sandbox with an egress-filtering sidecar and an auth proxy that keeps API keys out of the agent container.
 - [code-on-incus](https://github.com/mensfeld/code-on-incus) - Gives each agent its own Incus system container with root, systemd and Docker inside.
 - [clawker](https://github.com/schmitthub/clawker) - Self-hosted Docker sandboxes for coding agents, running behind an egress filter.
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) - Orchestrates persistent agent sessions through selectable local, Docker, Kubernetes and worker execution sandboxes; isolation depends on the backend.
 
 ## Process & namespace sandboxes
 


### PR DESCRIPTION
## Summary
- Add SandBase Harness to the Containers & gVisor supplementary sandbox list.
- Describe the selectable execution backends and explicitly qualify that isolation depends on the backend.

## Evidence
- Project: https://github.com/sandbaseai/sandbase-harness
- Sandbox backend documentation: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/usage.md#sandbox-backends
- Installation and deployment documentation: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md
- Current release: https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.8
- `git diff --check` passes.
- `python3 script/sandboxes-data.py --help` completed and generated data remained unchanged.

The description is intentionally conservative: SandBase Harness supports local, Docker, Kubernetes, and self-hosted Worker execution backends, while the actual isolation properties depend on the selected backend and deployment configuration. I maintain/contribute to the project and disclose that relationship here.
